### PR TITLE
Fixes issue 6.

### DIFF
--- a/data/test/parse/pass/issue_6.v
+++ b/data/test/parse/pass/issue_6.v
@@ -1,0 +1,3 @@
+wire x; // OK
+wire y; /* OK */
+wire /* OK */ z;

--- a/src/verilog/parse/verilog.ll
+++ b/src/verilog/parse/verilog.ll
@@ -74,7 +74,7 @@ parser->loc_.step();
 "+"       parser->text_ += yytext; return yyParser::make_PLUS(parser->loc_);
 "#"       parser->text_ += yytext; return yyParser::make_POUND(parser->loc_);
 "?"       parser->text_ += yytext; return yyParser::make_QMARK(parser->loc_);
-";"[ \t]* parser->text_ += yytext; return yyParser::make_SCOLON(parser->loc_);
+";"       parser->text_ += yytext; return yyParser::make_SCOLON(parser->loc_);
 "(*)"     parser->text_ += yytext; return yyParser::make_STAR(parser->loc_);
 "~&"      parser->text_ += yytext; return yyParser::make_TAMP(parser->loc_);
 "~^"      parser->text_ += yytext; return yyParser::make_TCARAT(parser->loc_);

--- a/test/parse.cc
+++ b/test/parse.cc
@@ -63,6 +63,9 @@ TEST(parse, pass_continuous_assign) {
 TEST(parse, pass_declaration) {
   run_parse("data/test/parse/pass/declaration.v", false);
 }
+TEST(parse, pass_issue_6) {
+  run_parse("data/test/parse/pass/issue_6.v", false);
+}
 TEST(parse, pass_issue_224) {
   run_parse("data/test/parse/pass/issue_224.v", false);
 }


### PR DESCRIPTION
## Overview

Removed vestigial token grabs after semicolon in verilog.ll which were causing parser errors.
Added testcase to show correctness.

Related issue(s) (if applicable): Fixes #6 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
