### PR TITLE
:green_heart: Add travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: cpp
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
 - "[ $CXX = clang++ ] && export CXX=clang++-3.8 || true"
 script:
   - make
-  - make check
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+language: cpp
+compiler:
+  - gcc
+  - clang
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.8
+    packages:
+    - ccache
+    - cmake
+    - flex
+    - bison
+    - libncurses-dev
+    - g++-6
+    - clang-3.8
+install:
+- "[ $CXX = g++ ] && export CXX=g++-6 || true"
+- "[ $CXX = clang++ ] && export CXX=clang++-3.8 || true"
+script:
+  - make
+  - make check

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ BIN=\
 
 ### Top-level commands
 all: ${BIN}
-check: ${GTEST_TARGET}
+test: ${GTEST_TARGET}
 	${MAKE} -C data/test/mips32/asm
 	${MAKE} -C data/test/regex/codegen
 	${MAKE} -C data/test/regex/data

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If the build didn't succeed (probably because you didn't use the ```--recursive`
 
 3. Check that the build succeeded (all tests should pass)
 ```
-*NIX $ make check
+*NIX $ make test
 ```
 
 Using Cascade


### PR DESCRIPTION
## Overview

Description: 
This PR adds Travis-CI checks, building under clang and gcc.
A future PR may separate the build using the matrix feature.

The build currently ensures that `make` and `make check` return error code 0.
We may want to consider renaming `make check` to `make test` which seems to be more idiomatic.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
