### PR TITLE
Coverage via codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,24 @@ matrix:
         - libncurses-dev
         - g++-6
         - clang-3.8
+  - os: linux
+    dist: xenial
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-precise-3.8
+        packages:
+        - ccache
+        - cmake
+        - flex
+        - bison
+        - libncurses-dev
+        - g++-6
+        - clang-3.8
+        - lcov
+    env:
+    - COVERAGE="1"
   - os: osx
     osx_image: xcode10.1
     addons:
@@ -29,18 +47,25 @@ matrix:
         - flex
         - bison
     env:
-      - LDFLAGS="-L/usr/local/opt/flex/lib -L/usr/local/opt/bison/lib"
-      - CPPFLAGS="-I/usr/local/opt/flex/include"
-      - CXXFLAGS="-I/usr/local/opt/flex/include"
-      - CFLAGS="-I/usr/local/opt/flex/include"
+    - LDFLAGS="-L/usr/local/opt/flex/lib -L/usr/local/opt/bison/lib"
+    - CPPFLAGS="-I/usr/local/opt/flex/include"
+    - CXXFLAGS="-I/usr/local/opt/flex/include"
+    - CFLAGS="-I/usr/local/opt/flex/include"
     before_install:
-      - "export PATH=/usr/local/opt/bison/bin:/usr/local/opt/flex/bin:$PATH"
+    - export PATH=/usr/local/opt/bison/bin:/usr/local/opt/flex/bin:$PATH
 compiler:
-  - gcc
-  - clang
+- gcc
+- clang
 install:
 - "[ $CXX = g++ ] && export CXX=g++-6 || true"
 - "[ $CXX = clang++ ] && export CXX=clang++-3.8 || true"
+- "[ $COVERAGE = 1 ] && export CFLAGS=-coverage $CFLAGS && export CXXFLAGS=-coverage $CXXFLAGS
+  && export LDFLAGS=-coverage $LDFLAGS || true"
 script:
-  - make
-  - make test
+- make
+- "[ $COVERAGE = 1 ] make test && gcov . || make test"
+after_success:
+- "[ $COVERAGE = 1 ] && bash <(curl -s https://codecov.io/bash) || true"
+env:
+  global:
+    secure: HCmvfaRvj3TmSB+KJA3zbIaLEBXKpv3ED4vnayNg93FTBaLtLw0W8XXk8Sa7pOU+u00rE+2tkC52nKdMikscJlcYZm3KBR2Zqh4Br/hnMVIeXCFs9LTrA6UZDBVs1AeXYYV1KwetcG03o5YZDYNvS8tRZs8Fwl7pZzlfms8wdFyqnG59MNY0znG6RC18eO/dFCu78f4urjYW9UrmEQzU5YyGFYhHH9SylXV5o8cL1+XHoIUlqhyYswZ/PgdBQTUGLvts5IeV+gsO1GD9ibxO5iAlJ4M9OpnFuAxWojKqNcA+GxoC3XH+6Uga09UV/5qXn6gkEnKtMJMoGTI8sWkYlJ8yp5XJqCJOCIfQ11yagp2e9pYogxLNfiC7OZ63q3CHnwNU3PRSJemhX9HwBvp2ZFa1NkQTmwk5tdLYCel0d8uGNqJgyNp7JpLMxA1Fo3yuvVDoRjB2RgT8SSH2CbSmMhsbqdaDtuOsW6JcV/GxnvqCj8KRM2HJNIkCZMY1lX8E0z/QnWcCWt3gKCQ6FzSsjUWZIXsvSPcgbUm7NMY6UXbPY4IkOQZ5+0cCM21s5NAozk8ln86pdjxRwlrpxjAn50jGgy29ZSxxaGvXKtdJ6NrUkZgtNC5AtVQE/NItEwF5KKvm9vqG9ug4IOldSjXEHExH8Z28hU1KhEV2K+JAjE0=


### PR DESCRIPTION
## Overview

Description: This PR adds code coverage testing via codecov. It adds a build to the Travis-CI matrix setting the environment variable COVERAGE=1, which builds with CXXFLAGS and CFLAGS -coverage, runs gcov, and submits the build to codecov (example: see https://codecov.io/gh/vmware/cascade/tree/9358751be73c6a8307d8b0f6d3551fd818013ab4) for visualization and tracking.

Coverage status checks (gates) require full codecov integration, which will be added once approved by the VMware org.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
