### PR TITLE
Fix Makefile Constants and Clang Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,30 +10,30 @@ matrix:
       apt:
         sources:
         - ubuntu-toolchain-r-test
-        - llvm-toolchain-precise-3.8
+        - llvm-toolchain-xenial-7
         packages:
         - ccache
         - cmake
         - flex
         - bison
         - libncurses-dev
-        - g++-6
-        - clang-3.8
+        - g++-8
+        - clang-7
   - os: linux
     dist: xenial
     addons:
       apt:
         sources:
         - ubuntu-toolchain-r-test
-        - llvm-toolchain-precise-3.8
+        - llvm-toolchain-xenial-7
         packages:
         - ccache
         - cmake
         - flex
         - bison
         - libncurses-dev
-        - g++-6
-        - clang-3.8
+        - g++-8
+        - clang-7
         - lcov
     env:
     - COVERAGE="1"
@@ -57,8 +57,6 @@ compiler:
 - gcc
 - clang
 install:
-- "[ $CXX = g++ ] && export CXX=g++-6 || true"
-- "[ $CXX = clang++ ] && export CXX=clang++-3.8 || true"
 - "[ $COVERAGE = 1 ] && export CFLAGS=-coverage $CFLAGS && export CXXFLAGS=-coverage $CXXFLAGS
   && export LDFLAGS=-coverage $LDFLAGS || true"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,21 @@ matrix:
   include:
   - os: linux
     dist: xenial
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - ccache
+        - cmake
+        - flex
+        - bison
+        - libncurses-dev
+        - g++-8
+  - os: linux
+    dist: xenial
+    compiler: clang
     addons:
       apt:
         sources:
@@ -17,7 +32,6 @@ matrix:
         - flex
         - bison
         - libncurses-dev
-        - g++-8
         - clang-7
   - os: linux
     dist: xenial
@@ -53,9 +67,6 @@ matrix:
     - CFLAGS="-I/usr/local/opt/flex/include"
     before_install:
     - export PATH=/usr/local/opt/bison/bin:/usr/local/opt/flex/bin:$PATH
-compiler:
-- gcc
-- clang
 install:
 - "[ $COVERAGE = 1 ] && export CFLAGS=-coverage $CFLAGS && export CXXFLAGS=-coverage $CXXFLAGS
   && export LDFLAGS=-coverage $LDFLAGS || true"

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 ### Target Attributes
 UNAME=$(shell uname)
 
-### Constants: g++
-CC=ccache gcc
-CXX=ccache g++ --std=c++14
+### Flags
 CC_OPT=\
 	-Werror -Wextra -Wall -Wfatal-errors -pedantic\
  	-Wno-deprecated-register
 CXX_OPT=\
-	-Werror -Wextra -Wall -Wfatal-errors -pedantic\
+	--std=c++14 -Werror -Wextra -Wall -Wfatal-errors -pedantic\
  	-Wno-overloaded-virtual -Wno-deprecated-register
 PERF=\
 	-march=native -fno-exceptions -fno-stack-protector \
@@ -133,25 +131,25 @@ submodule:
 	git submodule init
 	git submodule update
 bin/%: tools/%.cc ${FLEX_SRC} ${OBJ}
-	${CXX} ${CXXFLAGS} ${CXX_OPT} ${PERF} ${INC} $< -o $@ ${OBJ} ${LIB}
+	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} ${PERF} ${INC} $< -o $@ ${OBJ} ${LIB}
 ${FLEX_SRC}: src/verilog/parse/verilog.ll ${BISON_SRC}
 	cd src/verilog/parse && flex verilog.ll	
 ${BISON_SRC}: src/verilog/parse/verilog.yy
 	cd src/verilog/parse && bison -d -v verilog.yy
 %.o: %.c ${FLEX_SRC} ${BISON_SRC}
-	${CC} ${CFLAGS} ${CC_OPT} ${PERF} ${GTEST_INC} ${INC} -c $< -o $@
+	ccache ${CC} ${CFLAGS} ${CC_OPT} ${PERF} ${GTEST_INC} ${INC} -c $< -o $@
 %.o: %.cc ${FLEX_SRC} ${BISON_SRC} 
-	${CXX} ${CXXFLAGS} ${CXX_OPT} ${PERF} ${GTEST_INC} ${INC} -c $< -o $@
+	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} ${PERF} ${GTEST_INC} ${INC} -c $< -o $@
 ${GTEST_LIB}: submodule
 	mkdir -p ${GTEST_BUILD_DIR}
 	cd ${GTEST_BUILD_DIR} && CFLAGS=${CFLAGS} CXXFLAGS=${CXXFLAGS} cmake .. && make
 ${GTEST_TARGET}: ${FLEX_SRC} ${OBJ} ${TEST_OBJ} ${GTEST_LIB} ${GTEST_MAIN}
-	${CXX} ${CXXFLAGS} ${CXX_OPT} ${PERF} -o $@ ${TEST_OBJ} ${OBJ} ${GTEST_LIB} ${GTEST_MAIN} ${LIB} 
+	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} ${PERF} -o $@ ${TEST_OBJ} ${OBJ} ${GTEST_LIB} ${GTEST_MAIN} ${LIB} 
 
 ### Misc rules for targets that we don't control the source for
 ext/mongoose/mongoose.o: ext/mongoose/mongoose.c
-	${CC} ${CFLAGS} ${CC_OPT} ${PERF} -Wno-sign-compare -Wno-unused-parameter -Wno-format -Wno-format-pedantic ${GTEST_INC} ${INC} -c $< -o $@
+	ccache ${CC} ${CFLAGS} ${CC_OPT} ${PERF} -Wno-sign-compare -Wno-unused-parameter -Wno-format -Wno-format-pedantic ${GTEST_INC} ${INC} -c $< -o $@
 src/verilog/parse/lex.yy.o: src/verilog/parse/lex.yy.cc 
-	${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -fno-stack-protector -O3 -DNDEBUG -Wno-sign-compare ${GTEST_INC} ${INC} -c $< -o $@
+	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -fno-stack-protector -O3 -DNDEBUG -Wno-sign-compare ${GTEST_INC} ${INC} -c $< -o $@
 src/verilog/parse/verilog.tab.o: src/verilog/parse/verilog.tab.cc
-	${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -fno-stack-protector -O3 -DNDEBUG  ${GTEST_INC} ${INC} -c $< -o $@
+	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -fno-stack-protector -O3 -DNDEBUG  ${GTEST_INC} ${INC} -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ ${GTEST_TARGET}: ${FLEX_SRC} ${OBJ} ${TEST_OBJ} ${GTEST_LIB} ${GTEST_MAIN}
 
 ### Misc rules for targets that we don't control the source for
 ext/mongoose/mongoose.o: ext/mongoose/mongoose.c
-	ccache ${CC} ${CFLAGS} ${CC_OPT} ${PERF} -Wno-sign-compare -Wno-unused-parameter -Wno-format -Wno-format-pedantic ${GTEST_INC} ${INC} -c $< -o $@
+	ccache ${CC} ${CFLAGS} ${CC_OPT} ${PERF} -Wno-array-bounds -Wno-sign-compare -Wno-unused-parameter -Wno-format -Wno-format-pedantic ${GTEST_INC} ${INC} -c $< -o $@
 src/verilog/parse/lex.yy.o: src/verilog/parse/lex.yy.cc 
 	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -fno-stack-protector -O3 -DNDEBUG -Wno-sign-compare ${GTEST_INC} ${INC} -c $< -o $@
 src/verilog/parse/verilog.tab.o: src/verilog/parse/verilog.tab.cc

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,6 @@ ${GTEST_TARGET}: ${FLEX_SRC} ${OBJ} ${TEST_OBJ} ${GTEST_LIB} ${GTEST_MAIN}
 ext/mongoose/mongoose.o: ext/mongoose/mongoose.c
 	ccache ${CC} ${CFLAGS} ${CC_OPT} ${PERF} -Wno-array-bounds -Wno-sign-compare -Wno-unused-parameter -Wno-format -Wno-format-pedantic ${GTEST_INC} ${INC} -c $< -o $@
 src/verilog/parse/lex.yy.o: src/verilog/parse/lex.yy.cc 
-	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -fno-stack-protector -O3 -DNDEBUG -Wno-sign-compare ${GTEST_INC} ${INC} -c $< -o $@
+	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -Wno-null-conversion -fno-stack-protector -O3 -DNDEBUG -Wno-sign-compare ${GTEST_INC} ${INC} -c $< -o $@
 src/verilog/parse/verilog.tab.o: src/verilog/parse/verilog.tab.cc
 	ccache ${CXX} ${CXXFLAGS} ${CXX_OPT} -march=native -fno-stack-protector -O3 -DNDEBUG  ${GTEST_INC} ${INC} -c $< -o $@


### PR DESCRIPTION
## Overview

Description: The Makefile currently sets CXX and CC at the top under constants, preventing standard tooling from actually setting them to useful values. This was preventing Travis from correctly executing clang in the clang build matrix.

This PR corrects this issue by unsetting CXX and CC and moving the flags that were previously set elsewhere in the file. In addition, the Makefile is patched to correctly build under clang-7.

We really should look into cmake soon, as it appears that the current build system is quite fragile.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
