### PR TITLE
This commit fixes issue 41.

### DIFF
--- a/data/test/simple/issue_41a.v
+++ b/data/test/simple/issue_41a.v
@@ -1,0 +1,8 @@
+wire signed[31:0] minus_one = -1;
+wire signed[31:0] left_shifted = minus_one <<< 1;
+wire signed[31:0] test = left_shifted >>> 1;
+
+initial begin
+    $write(test);
+    $finish;
+end

--- a/data/test/simple/issue_41b.v
+++ b/data/test/simple/issue_41b.v
@@ -1,0 +1,8 @@
+// tests whether both top and non-top words are built correctly
+wire signed[68:0] minus_sixteen = -16;
+wire signed[68:0] test = minus_sixteen >>> 2;
+
+initial begin
+    $write(test);
+    $finish;
+end

--- a/src/base/bits/bits.h
+++ b/src/base/bits/bits.h
@@ -1290,7 +1290,7 @@ inline void BitsBase<T, BT, ST>::bitwise_sxr_const(size_t samt, bool arith, Bits
   // we want the top bits of the top-most word to be filled with ones.
   // This is only used in the case where hob is set and the top word is not
   // completely full.
-  T upper_most_word = ((-1 << idx) | val_.back());
+  const auto upper_most_word = ((T(-1) << idx) | val_.back());
 
   // Work our way up until top goes out of range
   size_t w = 0;
@@ -1298,7 +1298,7 @@ inline void BitsBase<T, BT, ST>::bitwise_sxr_const(size_t samt, bool arith, Bits
     if (bamt == 0) {
       res.val_[w] = val_[t];
     } else {
-      T upper_most = (t == val_.size() - 1) ? upper_most_word : val_[t];
+      const auto upper_most = (t == val_.size() - 1) ? upper_most_word : val_[t];
       res.val_[w] = (val_[t-1] >> bamt) | ((upper_most & mask) << mamt);
     }
   }

--- a/src/base/bits/bits.h
+++ b/src/base/bits/bits.h
@@ -1286,6 +1286,11 @@ inline void BitsBase<T, BT, ST>::bitwise_sxr_const(size_t samt, bool arith, Bits
   // Create a mask for extracting the lowest bamt bits from top
   const auto mamt = bits_per_word() - bamt;
   const auto mask = (T(1) << bamt) - 1;
+  // val_ is an array of unsigned values. If we are working with signed values,
+  // we want the top bits of the top-most word to be filled with ones.
+  // This is only used in the case where hob is set and the top word is not
+  // completely full.
+  T upper_most_word = ((-1 << idx) | val_.back());
 
   // Work our way up until top goes out of range
   size_t w = 0;
@@ -1293,12 +1298,13 @@ inline void BitsBase<T, BT, ST>::bitwise_sxr_const(size_t samt, bool arith, Bits
     if (bamt == 0) {
       res.val_[w] = val_[t];
     } else {
-      res.val_[w] = (val_[t-1] >> bamt) | ((val_[t] & mask) << mamt);
+      T upper_most = (t == val_.size() - 1) ? upper_most_word : val_[t];
+      res.val_[w] = (val_[t-1] >> bamt) | ((upper_most & mask) << mamt);
     }
   }
   // There's one more block to build where top is implicitly zero
   if (hob) {
-    res.val_[w++] = (bamt == 0) ? T(-1) : ((val_.back() >> bamt) | (mask << mamt));
+    res.val_[w++] = (bamt == 0) ? T(-1) : ((upper_most_word >> bamt) | (mask << mamt));
   } else {
     res.val_[w++] = (bamt == 0) ? T(0) : (val_.back() >> bamt);
   }

--- a/src/verilog/analyze/evaluate.cc
+++ b/src/verilog/analyze/evaluate.cc
@@ -586,11 +586,17 @@ void Evaluate::SelfDetermine::edit(BinaryExpression* be) {
       break;
     case BinaryExpression::GGT:
     case BinaryExpression::LLT:
+      w = be->get_lhs()->bit_val_[0].size();
+      s = be->get_lhs()->bit_val_[0].is_signed();
+      break;
     case BinaryExpression::TTIMES:
+      w = be->get_lhs()->bit_val_[0].size();
+      s = false;
+      break;
     case BinaryExpression::GGGT:
     case BinaryExpression::LLLT:
       w = be->get_lhs()->bit_val_[0].size();
-      s = false;
+      s = be->get_lhs()->bit_val_[0].is_signed();
       break;
     default:
       assert(false);

--- a/test/simple.cc
+++ b/test/simple.cc
@@ -279,3 +279,9 @@ TEST(simple, sign_2) {
 //TEST(simple, while_1) {
 //  run_code("minimal","data/test/simple/while_1.v", "333");
 //}
+TEST(simple, issue_41a) {
+    run_code("minimal","data/test/simple/issue_41a.v", "-1");
+}
+TEST(simple, issue_41b) {
+    run_code("minimal","data/test/simple/issue_41b.v", "-4");
+}


### PR DESCRIPTION


## Overview
This PR fixes the >>> operator by accounting for the fact that in cases
where the length of the register is not divisible by the word size, the topmost
word will be padded by zeroes instead of ones even when the register is signed.

Related issue(s) (if applicable): Fixes #41 

