### PR TITLE
Incorrect variable name in assert

### DIFF
--- a/src/target/core/de10/de10_logic.cc
+++ b/src/target/core/de10/de10_logic.cc
@@ -279,7 +279,7 @@ void De10Logic::finalize() {
     // var info for those check in the index as well, so we can quickly(*ish*) update those
     // values whenever we interact with this stream
     const auto itr = eof_checks_.find(r);
-    assert(itr != eof_check_.end());
+    assert(itr != eof_checks_.end());
     for (auto* i : itr->second) {
       const auto titr = table_find(i);
       assert(titr != table_end());


### PR DESCRIPTION
## Overview

Description: The PR fixes an issue in de10_logic.cc where an incorrect variable name is being used in an assert. 

This was caught by CI for the commit: https://github.com/vmware/cascade/runs/110211136 , but only on assert and clang builds, since the assert() macro is only evaluated in GCC if DEBUG is set. This PR correctly renames the variable.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
