### PR TITLE
Remove assert that accesses out-of-scope pd

### DIFF
--- a/src/verilog/parse/verilog.yy
+++ b/src/verilog/parse/verilog.yy
@@ -548,7 +548,6 @@ module_or_generate_item
   /* TODO | attribute_instance_S udp_instantiation */
   | attribute_instance_S module_instantiation { 
     for (auto mi : $2) {
-      assert(pd->is(Node::Tag::port_declaration));
       static_cast<ModuleInstantiation*>(mi)->replace_attrs($1->clone());
     }
     delete $1;


### PR DESCRIPTION
## Overview

Description: The verilog.yy file tries to assert on a out-of-scope variable pd. The generated code is below:

```
#line 549 "../src/verilog/parse/verilog.yy" // lalr1.cc:907
    { 
    for (auto mi : yystack_[0].value.as< std::vector<ModuleItem*> > ()) {
      assert(pd->is(Node::Tag::port_declaration));
      static_cast<ModuleInstantiation*>(mi)->replace_attrs(yystack_[1].value.as< Attributes* > ()->clone());
    }
    delete yystack_[1].value.as< Attributes* > ();
    yylhs.value.as< std::vector<ModuleItem*> > () = yystack_[0].value.as< std::vector<ModuleItem*> > ();
  }
```
Scoping rules result in this error:
```
[build] In file included from /usr/local/Cellar/gcc/8.2.0/include/c++/8.2.0/cassert:44,
[build]                  from /cascade/build/lib/verilog_parser.hh:94,
[build]                  from /cascade/build/lib/verilog_parser.cc:40:
[build] ../src/verilog/parse/verilog.yy: In member function 'virtual int cascade::yyParser::parse()':
[build] ../src/verilog/parse/verilog.yy:551:14: error: 'pd' was not declared in this scope
[build] ../src/verilog/parse/verilog.yy:551:14: note: suggested alternative: 'Id'
```
This PR fixes the error by removing the assertion.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
