### PR TITLE
use google benchmark, add microbenchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ pmm(
         BINCRAFTERS
         COMMUNITY
         SETTINGS compiler.libcxx=${cxxlib} ${force_compiler}
+        REMOTES mpusz https://api.bintray.com/conan/mpusz/conan-mpusz
     )
 
 include(CTest)

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,4 +4,4 @@ class Cascade(conans.ConanFile):
     name = 'cascade'
     version = '0.0.1'
     generators = 'cmake'
-    requires = ('gtest/1.8.1@bincrafters/stable', 'ncurses/6.1@conan/stable')
+    requires = ('gtest/1.8.1@bincrafters/stable', 'ncurses/6.1@conan/stable', 'google-benchmark/1.4.1@mpusz/stable')

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 project(cascade-test)
 
 file (GLOB_RECURSE REGRESSION_DIR "regression/*.cc")
-file (GLOB_RECURSE BENCHMARK_DIR "benchmark/*.cc")
 
 include_directories(../lib)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -12,9 +11,13 @@ add_executable(regression harness.cc ${REGRESSION_DIR})
 target_link_libraries(regression CONAN_PKG::gtest)
 target_link_libraries(regression libcascade verilog)
 
-add_executable(benchmark harness.cc ${BENCHMARK_DIR})
-target_link_libraries(benchmark CONAN_PKG::gtest)
+add_executable(benchmark harness.cc benchmark/benchmark.cc)
+target_link_libraries(benchmark CONAN_PKG::gtest CONAN_PKG::google-benchmark)
 target_link_libraries(benchmark libcascade verilog)
+
+add_executable(microbenchmark harness.cc benchmark/microbenchmark.cc)
+target_link_libraries(microbenchmark CONAN_PKG::gtest CONAN_PKG::google-benchmark)
+target_link_libraries(microbenchmark libcascade verilog)
 
 add_test(NAME regression 
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/regression 

--- a/test/benchmark/benchmark.cc
+++ b/test/benchmark/benchmark.cc
@@ -30,31 +30,51 @@
 
 #include <string>
 #include "cl.h"
-#include "gtest/gtest.h"
 #include "harness.h"
+#include "benchmark/benchmark.h"
 
 using namespace cascade;
 using namespace cl;
 using namespace std;
 
-int main(int argc, char** argv) {
-  Simple::read(argc, argv);
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+BENCHMARK_MAIN();
 
-TEST(benchmark, array) {
-  run_benchmark("data/test/benchmark/array/run_7.v", "268435457\n");
+static void BM_Array(benchmark::State& state) 
+{
+  for(auto _ : state) {
+    run_benchmark("data/test/benchmark/array/run_7.v", "268435457\n");
+  }
 }
-TEST(benchmark, bitcoin) {
-  run_benchmark("data/test/benchmark/bitcoin/run_20.v", "1ce5c0 1ce5c5\n");
+BENCHMARK(BM_Array)->Unit(benchmark::kMillisecond);
+
+static void BM_Bitcoin(benchmark::State& state) 
+{
+  for(auto _ : state) {
+    run_benchmark("data/test/benchmark/bitcoin/run_20.v", "1ce5c0 1ce5c5\n");
+  }
 }
-TEST(benchmark, mips32) {
-  run_benchmark("data/test/benchmark/mips32/run_bubble_128_1024.v", "1");
+BENCHMARK(BM_Bitcoin)->Unit(benchmark::kMillisecond);
+
+static void BM_Mips32(benchmark::State& state) 
+{
+  for(auto _ : state) {
+    run_benchmark("data/test/benchmark/mips32/run_bubble_128_1024.v", "1");
+  }
 }
-TEST(benchmark, regex) {
-  run_benchmark("data/test/benchmark/regex/run_disjunct_64.v", "27136");
+BENCHMARK(BM_Mips32)->Unit(benchmark::kMillisecond);
+
+static void BM_Regex(benchmark::State& state) 
+{
+  for(auto _ : state) {
+    run_benchmark("data/test/benchmark/regex/run_disjunct_64.v", "27136");
+  }
 }
-TEST(benchmark, nw) {
-  run_benchmark("data/test/benchmark/nw/run_8.v", "-24576");
+BENCHMARK(BM_Regex)->Unit(benchmark::kMillisecond);
+
+static void BM_Nw(benchmark::State& state) 
+{
+  for(auto _ : state) {
+    run_benchmark("data/test/benchmark/nw/run_8.v", "-24576");
+  }
 }
+BENCHMARK(BM_Nw)->Unit(benchmark::kMillisecond);

--- a/test/benchmark/microbenchmark.cc
+++ b/test/benchmark/microbenchmark.cc
@@ -1,0 +1,172 @@
+// Copyright 2017-2019 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// The BSD-2 license (the License) set forth below applies to all parts of the
+// Cascade project.  You may not use this file except in compliance with the
+// License.
+//
+// BSD-2 License
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <string>
+#include "cl.h"
+#include "base/system/system.h"
+#include "benchmark/benchmark.h"
+#include "verilog/parse/parser.h"
+#include "cascade.h"
+#include "ui/view.h"
+#include "harness.h"
+
+
+using namespace cascade;
+using namespace cl;
+using namespace std;
+
+BENCHMARK_MAIN();
+
+static void BM_Parser(benchmark::State& state, string code) 
+{
+    stringstream ss(code);
+
+    Log log;
+    Parser p(&log);
+
+    for(auto _ : state) {
+        ss.clear();
+        ss.str(code);
+        p.set_stream(ss);
+        p.parse();
+    }
+}
+
+BENCHMARK_CAPTURE(BM_Parser, parse_empty, "");
+
+BENCHMARK_CAPTURE(BM_Parser, parse_and, 
+R"verilog(
+    module and(x,y,z);
+        input wire x;
+        input wire y;
+        output wire z;
+
+        assign z = x & y;
+    endmodule
+)verilog");
+
+BENCHMARK_CAPTURE(BM_Parser, parse_array, 
+R"verilog(
+    module Array();
+
+    parameter W = 2;
+    parameter FINISH = 0;
+
+    localparam N = (1 << W) - 1;
+    localparam K = 3*W;
+
+    reg[W-1:0] low;
+    reg[K:0]   mid  [N:0];    
+    reg        high [1:0][1:0][1:0];
+
+    reg[63:0] COUNT = 0;
+    always @(posedge clock.val) begin
+        low <= low + 1;
+        mid[low] <= mid[low] + 1; 
+        high[mid[N][K]][mid[N][1]][mid[N][0]] <= high[mid[N][K]][mid[N][1]][mid[N][0]] + 1;
+
+        if (high[1][0][0]) begin
+        $display(COUNT);
+        $finish(FINISH); 
+        end else
+        COUNT <= COUNT + 1;
+    end
+
+    endmodule
+
+    Array#(.W(7)) array();
+)verilog");
+
+static void BM_Code(benchmark::State& state, string code) 
+{
+    for(auto _ : state) {
+        stringstream ss;
+
+        Cascade c;
+        c.set_include_path(System::src_root());
+        c.attach_view(new PView(ss));
+        c.run();
+
+        c.eval("`include \"data/march/minimal.v\"\n" + code);
+
+        c.wait_for_stop();
+    }
+}
+
+BENCHMARK_CAPTURE(BM_Code, code_empty, R"verilog(initial $finish;)verilog");
+
+static void BM_CodeArray(benchmark::State& state)
+{
+    const string array_code = R"verilog(
+    module Array();
+
+    parameter W = 2;
+    parameter FINISH = 0;
+
+    localparam N = (1 << W) - 1;
+    localparam K = 3*W;
+
+    reg[W-1:0] low;
+    reg[K:0]   mid  [N:0];    
+    reg        high [1:0][1:0][1:0];
+
+    reg[63:0] COUNT = 0;
+    always @(posedge clock.val) begin
+        low <= low + 1;
+        mid[low] <= mid[low] + 1; 
+        high[mid[N][K]][mid[N][1]][mid[N][0]] <= high[mid[N][K]][mid[N][1]][mid[N][0]] + 1;
+
+        if (high[1][0][0]) begin
+        $display(COUNT);
+        $finish(FINISH); 
+        end else
+        COUNT <= COUNT + 1;
+    end
+
+    endmodule
+    )verilog";
+
+    const string instantiation_code = "Array#(.W(" + to_string(state.range(0)) + ")) array();";
+
+    for(auto _ : state) {
+        stringstream ss;
+
+        Cascade c;
+        c.set_include_path(System::src_root());
+        c.attach_view(new PView(ss));
+        c.run();
+
+        c.eval("`include \"data/march/minimal.v\"\n" + array_code + instantiation_code);
+
+        c.wait_for_stop();
+    }
+}
+
+BENCHMARK(BM_CodeArray)->Range(2,5)->Complexity();


### PR DESCRIPTION
## Overview

This PR switches the benchmarking infrastructure to Google Benchmark (https://github.com/google/benchmark). It also introduces a minimal set of microbenchmarks, which are separate from the benchmarks as they have a long running time. The microbenchmarks currently only test parsing time and running time of the array benchmark.

Sample output is below:
```
~/d/cascade ❯❯❯ build/test/microbenchmark                                                                                                                                       
2019-05-18 16:11:56
Running build/test/microbenchmark
Run on (8 X 2900 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 8388K (x1)
-------------------------------------------------------------
Benchmark                      Time           CPU Iterations
-------------------------------------------------------------
BM_Parser/parse_empty       3879 ns       3749 ns     192009
BM_Parser/parse_and        39694 ns      38743 ns      18670
BM_Parser/parse_array     232644 ns     223098 ns       3048
BM_Code/code_empty       7486628 ns     361397 ns       1000
BM_CodeArray/2           8496808 ns     522604 ns       1393
BM_CodeArray/5        1592732134 ns     604400 ns         10
BM_CodeArray_BigO     800614470.74 (1)  563502.23 (1) 
BM_CodeArray_RMS              99 %          7 % 
```

In the future, it would be useful to be able to reset a Cascade instance, as the benchmarks include some setup time (~10ms) as it is currently not possible to reuse a cascade instance. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
