### PR TITLE
Fix cmake build for arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,18 @@ else ()
     set(force_compiler "")
 endif()
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^armv7*")
+    set(force_arch "armv7")
+else()
+    set(force_arch ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
 pmm(
     CONAN
         BUILD missing
         BINCRAFTERS
         COMMUNITY
-        SETTINGS compiler.libcxx=${cxxlib} ${force_compiler}
+        SETTINGS compiler.libcxx=${cxxlib} ${force_compiler} arch=${force_arch}
         REMOTES mpusz https://api.bintray.com/conan/mpusz/conan-mpusz
     )
 


### PR DESCRIPTION
## Overview

This PR fixes an issue with cmake and pmm, where the architecture was assumed to be x86. This PR sets the architecture to armv7 for ARM or CMAKE_SYSTEM_PROCESSOR for all other platforms.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
