### PR TITLE
Add ARM ci support in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,101 +1,87 @@
 dist: xenial
 language: cpp
-matrix:
-  fast_finish: true
+
+jobs:
   include:
-  - os: linux
-    compiler: gcc
+  - &chroot
+    stage: Prepare Build Environment
+    os: linux
     dist: xenial
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - ccache
-        - cmake
-        - flex
-        - bison
-        - g++-8
-        - python3-venv
+    install: echo "Building Ubuntu chroot environment..."
+    script: .travis/generate_env.sh
+    before_cache: .travis/unmount_env.sh
     cache:
       directories:
-      - $HOME/.conan/data
-    before_install:
-      - export CC="/usr/bin/gcc-8"
-      - export CXX="/usr/bin/g++-8"
-  - os: linux
-    compiler: clang
-    dist: xenial
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        - llvm-toolchain-xenial-8
-        packages:
-        - python3-venv
-        - ccache
-        - cmake
-        - flex
-        - bison
-        - clang-8
-        - libc++-dev
-        - libc++abi-dev
-    cache:
-      directories:
-      - $HOME/.conan/data
-    before_install:
-      - export CC="/usr/bin/clang-8"
-      - export CXX="/usr/bin/clang++-8"
-      - sudo ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
-  - os: linux
-    dist: xenial
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - python3-venv
-        - ccache
-        - cmake
-        - flex
-        - bison
-        - g++-8
-      sonarcloud:
-        organization: cascade
-    cache:
-      directories:
-      - $HOME/.conan/data
+        - $HOME/$ARCH
+    env: 
+      ARCH=amd64
+  - <<: *chroot
     env:
-      - COVERAGE="1"
-    before_install:
-      - export CC="/usr/bin/gcc-8"
-      - export CXX="/usr/bin/g++-8"
-      - sudo ln -sf /usr/bin/gcov-8 /usr/bin/gcov 
-      - wget http://downloads.sourceforge.net/ltp/lcov-1.14.tar.gz
-      - tar xvfz lcov-1.14.tar.gz
-      - cd lcov-1.14; make; sudo make install; cd ..
-  - os: osx
+      ARCH=armhf
+  - &depends
+    stage: Setup Build and Install Dependencies
+    os: linux
+    dist: xenial
+    before_install: .travis/setup_chroot.sh
+    script: echo "install deps"
+    install: .travis/setup_build.sh
+    before_cache: .travis/unmount_env.sh
+    cache: 
+      directories:
+        - $HOME/$ARCH
+        - $HOME/.conan/data
+    env: 
+      ARCH=amd64
+  - <<: *depends
+    os: osx
     osx_image: xcode10.1
     compiler: clang
     addons:
       homebrew:
+        update: true
         packages:
-        - ccache
-        - cmake
-        - flex
-        - bison
-    cache:
+          - flex
+          - bison
+  - <<: *depends
+    env:
+      ARCH=armhf
+  - &build
+    stage: Build Cascade
+    os: linux
+    dist: xenial
+    before_install: .travis/setup_chroot.sh
+    script: echo "build"
+    install: .travis/install.sh
+    before_cache: .travis/unmount_env.sh
+    cache: 
       directories:
-      - $HOME/.conan/data
-      - $HOME/.pyenv/versions/2.7.10/
-      - /usr/local/Homebrew
-script:
-- mkdir -p ~/.conan && cp .travis/conan_settings.yml ~/.conan/settings.yml
-- ./setup --silent --ci --coverage=$COVERAGE
-after_success:
-- "[ $COVERAGE = 1 ] && curl -L https://codecov.io/bash -o codecov.sh; bash codecov.sh -x gcov 2>&1 | grep -v 'has arcs to entry block' | grep -v 'has arcs from exit block' && cd .. && sonar-scanner -Dsonar.projectKey=cascade
-  -Dsonar.organization=cascade -Dsonar.sources=lib,src,tools -Dsonar.tests=test -Dsonar.cfamily.build-wrapper-output=build/bw-output -Dsonar.cfamily.gcov.reportsPath=build
-  -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.exclusions=cascade_coverage/*,**/cascade_coverage/*,**/verilog_parser.cc,**/verilog_parser.hh,**/verilog_lexer.cc -Dsonar.cfamily.threads=$(getconf _NPROCESSORS_ONLN) || true"
+        - $HOME/$ARCH
+        - $HOME/.conan/data
+    env: 
+      ARCH=amd64
+  - <<: *build
+    os: osx
+    osx_image: xcode10.1
+    compiler: clang
+    addons:
+      homebrew:
+        update: true
+        packages:
+          - flex
+          - bison
+    env:
+      ARCH=amd64  
+  - <<: *build
+    env:
+      ARCH=armhf
+  - <<: *build
+    name: Coverage, Debug
+    install: COVERAGE=1 .travis/install.sh
+    env:
+      ARCH=amd64
+    addons:
+      sonarcloud:
+        organization: cascade
 env:
   global:
   - secure: HCmvfaRvj3TmSB+KJA3zbIaLEBXKpv3ED4vnayNg93FTBaLtLw0W8XXk8Sa7pOU+u00rE+2tkC52nKdMikscJlcYZm3KBR2Zqh4Br/hnMVIeXCFs9LTrA6UZDBVs1AeXYYV1KwetcG03o5YZDYNvS8tRZs8Fwl7pZzlfms8wdFyqnG59MNY0znG6RC18eO/dFCu78f4urjYW9UrmEQzU5YyGFYhHH9SylXV5o8cL1+XHoIUlqhyYswZ/PgdBQTUGLvts5IeV+gsO1GD9ibxO5iAlJ4M9OpnFuAxWojKqNcA+GxoC3XH+6Uga09UV/5qXn6gkEnKtMJMoGTI8sWkYlJ8yp5XJqCJOCIfQ11yagp2e9pYogxLNfiC7OZ63q3CHnwNU3PRSJemhX9HwBvp2ZFa1NkQTmwk5tdLYCel0d8uGNqJgyNp7JpLMxA1Fo3yuvVDoRjB2RgT8SSH2CbSmMhsbqdaDtuOsW6JcV/GxnvqCj8KRM2HJNIkCZMY1lX8E0z/QnWcCWt3gKCQ6FzSsjUWZIXsvSPcgbUm7NMY6UXbPY4IkOQZ5+0cCM21s5NAozk8ln86pdjxRwlrpxjAn50jGgy29ZSxxaGvXKtdJ6NrUkZgtNC5AtVQE/NItEwF5KKvm9vqG9ug4IOldSjXEHExH8Z28hU1KhEV2K+JAjE0=

--- a/.travis/generate_env.sh
+++ b/.travis/generate_env.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir $HOME/$ARCH
+
+wget http://cdimage.ubuntu.com/ubuntu-base/releases/18.04.2/release/ubuntu-base-18.04.2-base-$ARCH.tar.gz -O ubuntu.tar.gz
+sudo tar xzf ubuntu.tar.gz -C $HOME/$ARCH
+
+if [ $ARCH == "armhf" ]; then
+    QEMU_ARCH="arm"
+    wget https://github.com/multiarch/qemu-user-static/releases/download/v4.0.0-2/qemu-${QEMU_ARCH}-static
+    chmod a+x qemu-${QEMU_ARCH}-static
+    sudo cp qemu-${QEMU_ARCH}-static $HOME/$ARCH/usr/bin
+    docker run --rm --privileged multiarch/qemu-user-static:register
+fi
+
+sudo cp /etc/resolv.conf $HOME/$ARCH/etc/resolv.conf
+sudo cp /etc/passwd $HOME/$ARCH/etc/passwd
+sudo cp /etc/shadow $HOME/$ARCH/etc/shadow
+sudo mount -o bind /dev $HOME/$ARCH/dev
+sudo mount -o bind /proc $HOME/$ARCH/proc
+sudo mount -o bind /sys $HOME/$ARCH/sys
+sudo mount -o bind /dev/pts $HOME/$ARCH/dev/pts
+sudo mkdir $HOME/$ARCH/cascade
+sudo mount -o bind . $HOME/$ARCH/cascade
+sudo mount -o bind /home $HOME/$ARCH/home
+sudo chroot $HOME/$ARCH /bin/bash -c "apt-get update;apt-get install -y sudo build-essential cmake git python3 python3-venv python3-dev flex bison;sudo apt-get autoclean;sudo apt-get clean;sudo apt-get autoremove"
+sudo chmod -R a+rw $HOME/$ARCH/root
+sudo chmod -R a+rw $HOME/$ARCH/etc
+sudo chmod -R a+rw $HOME/$ARCH/var
+git config --global protocol.version 1

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+mkdir -p ~/.conan && cp .travis/conan_settings.yml ~/.conan/settings.yml
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+./setup --silent --ci --coverage=$COVERAGE
+else
+
+if [[ "$COVERAGE" == 1 ]]; then
+sudo chroot $HOME/$ARCH /bin/bash -c "apt-get install -y lcov"
+fi
+
+sudo chroot --userspec travis:travis $HOME/$ARCH /bin/bash -c "cd /cascade && ./setup --silent --ci --coverage=$COVERAGE"
+
+if [[ "$COVERAGE" == 1 ]]; then
+curl -L https://codecov.io/bash -o codecov.sh
+bash codecov.sh -x gcov 2>&1 | grep -v 'has arcs to entry block' | grep -v 'has arcs from exit block' 
+
+# Move on if we can't submit coverage
+cd .. && sonar-scanner -Dsonar.projectKey=cascade -Dsonar.organization=cascade -Dsonar.sources=lib,src,tools -Dsonar.tests=test -Dsonar.cfamily.build-wrapper-output=build/bw-output -Dsonar.cfamily.gcov.reportsPath=build -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.exclusions=cascade_coverage/*,**/cascade_coverage/*,**/verilog_parser.cc,**/verilog_parser.hh,**/verilog_lexer.cc -Dsonar.cfamily.threads=$(getconf _NPROCESSORS_ONLN) || true
+fi
+fi

--- a/.travis/setup_build.sh
+++ b/.travis/setup_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+mkdir -p ~/.conan && cp .travis/conan_settings.yml ~/.conan/settings.yml
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+./setup --pre-ci --coverage=$COVERAGE
+else
+sudo chroot --userspec travis:travis $HOME/$ARCH /bin/bash -c "cd /cascade && ./setup --pre-ci --coverage=$COVERAGE"
+fi

--- a/.travis/setup_chroot.sh
+++ b/.travis/setup_chroot.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+echo "macos doesn't use chroot, no need to mount."
+else
+
+if [ $ARCH == "armhf" ]; then
+    docker run --rm --privileged multiarch/qemu-user-static:register
+fi
+
+sudo mount -o bind /dev $HOME/$ARCH/dev
+sudo mount -o bind /proc $HOME/$ARCH/proc
+sudo mount -o bind /sys $HOME/$ARCH/sys
+sudo mount -o bind /dev/pts $HOME/$ARCH/dev/pts
+sudo mount -o bind . $HOME/$ARCH/cascade
+sudo mount -o bind /home $HOME/$ARCH/home
+
+git config --global protocol.version 1
+fi

--- a/.travis/unmount_env.sh
+++ b/.travis/unmount_env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+echo "macos doesn't use chroot, no need to unmount."
+else
+echo "Unmounting chroot mount points..."
+sudo umount $HOME/$ARCH/dev/pts
+sudo umount $HOME/$ARCH/dev
+sudo umount $HOME/$ARCH/proc
+sudo umount $HOME/$ARCH/sys
+sudo umount $HOME/$ARCH/cascade
+sudo umount $HOME/$ARCH/home
+fi

--- a/setup
+++ b/setup
@@ -54,6 +54,11 @@ case $i in
     --debug)
     BUILD_TYPE="Debug"
     ;;
+    --pre-ci)
+    SILENT=1
+    DO_INSTALL=0
+    DO_BUILD=0
+    ;;
     --ci)
     SILENT=1
     ;;   
@@ -185,10 +190,12 @@ case "${unameOut}" in
                     echo -e "Checking for required dpkg packages..."
                     MISSING=()
                     check_dpkg g++ MISSING
+                    check_dpkg git MISSING
                     check_dpkg cmake MISSING
                     check_dpkg flex MISSING
                     check_dpkg bison MISSING
                     check_dpkg python3-venv MISSING
+                    check_dpkg python3-dev MISSING
                     MISSING_LIST=$(printf " %s" "${MISSING[@]:1}")
                     MISSING_LIST=${MISSING_LIST:1}
                     if [ ${#MISSING[@]} -gt 0 ]; then 


### PR DESCRIPTION
## Overview

Description:  This PR introduces ARM CI support on Travis. 

This PR builds Cascade and dependencies in an ARM architectural chroot.

To facilitate the much longer build time and to satisfy the constraints of the 50 minute Travis timeout, the build is broken into stages: setting up the environment, building the dependencies, and then actually building and testing Cascade. 

This paves the path to generating a full image for an ARM system, such as the DE-10 in Travis as well.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
