### PR TITLE
Add Python3 as macos dependency

### DIFF
--- a/setup
+++ b/setup
@@ -235,6 +235,7 @@ case "${unameOut}" in
                 check_homebrew cmake MISSING
                 check_homebrew flex MISSING
                 check_homebrew bison MISSING
+                check_homebrew python3 MISSING
                 MISSING_LIST=$(printf " %s" "${MISSING[@]:1}")
                 MISSING_LIST=${MISSING_LIST:1}
                 if [ ${#MISSING[@]} -gt 0 ]; then 


### PR DESCRIPTION
## Overview

Description: In some macos systems, python3 may not be available. This PR adds a homebrew check.

Related issue(s) (if applicable): Fixes #147
## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
