### PR TITLE
arm: also use --privileged in setup_chroot.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
     before_cache: .travis/unmount_env.sh
     cache: 
       directories:
-        - $HOME/.conan/data
+        - $HOME/$ARCH
     env: 
       ARCH=amd64
   - <<: *build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,33 +18,6 @@ jobs:
   - <<: *chroot
     env:
       ARCH=armhf
-  - &depends
-    stage: Setup Build and Install Dependencies
-    os: linux
-    dist: xenial
-    before_install: .travis/setup_chroot.sh
-    script: echo "install deps"
-    install: .travis/setup_build.sh
-    before_cache: .travis/unmount_env.sh
-    cache: 
-      directories:
-        - $HOME/$ARCH
-        - $HOME/.conan/data
-    env: 
-      ARCH=amd64
-  - <<: *depends
-    os: osx
-    osx_image: xcode10.1
-    compiler: clang
-    addons:
-      homebrew:
-        update: true
-        packages:
-          - flex
-          - bison
-  - <<: *depends
-    env:
-      ARCH=armhf
   - &build
     stage: Build Cascade
     os: linux
@@ -55,7 +28,6 @@ jobs:
     before_cache: .travis/unmount_env.sh
     cache: 
       directories:
-        - $HOME/$ARCH
         - $HOME/.conan/data
     env: 
       ARCH=amd64

--- a/.travis/generate_env.sh
+++ b/.travis/generate_env.sh
@@ -11,7 +11,7 @@ if [ $ARCH == "armhf" ]; then
     wget https://github.com/multiarch/qemu-user-static/releases/download/v4.0.0-2/qemu-${QEMU_ARCH}-static
     chmod a+x qemu-${QEMU_ARCH}-static
     sudo cp qemu-${QEMU_ARCH}-static $HOME/$ARCH/usr/bin
-    docker run --rm --privileged multiarch/qemu-user-static:register --credential
+    docker run --rm --privileged multiarch/qemu-user-static:register --credential yes
 fi
 
 sudo cp /etc/resolv.conf $HOME/$ARCH/etc/resolv.conf

--- a/.travis/generate_env.sh
+++ b/.travis/generate_env.sh
@@ -24,6 +24,9 @@ sudo mount -o bind /dev/pts $HOME/$ARCH/dev/pts
 sudo mkdir $HOME/$ARCH/cascade
 sudo mount -o bind . $HOME/$ARCH/cascade
 sudo mount -o bind /home $HOME/$ARCH/home
+# Remove /etc/sudoers before starting in case it is cached
+# Otherwise, sudo install will get stuck
+sudo rm $HOME/$ARCH/etc/sudoers
 sudo chroot $HOME/$ARCH /bin/bash -c "apt-get update;apt-get install -y sudo build-essential cmake git python3 python3-venv python3-dev flex bison;sudo apt-get autoclean;sudo apt-get clean;sudo apt-get autoremove"
 sudo chown root:root $HOME/$ARCH/usr/bin/sudo
 sudo chmod 4755 $HOME/$ARCH//usr/bin/sudo

--- a/.travis/setup_chroot.sh
+++ b/.travis/setup_chroot.sh
@@ -7,7 +7,8 @@ echo "macos doesn't use chroot, no need to mount."
 else
 
 if [ $ARCH == "armhf" ]; then
-    docker run --rm --privileged multiarch/qemu-user-static:register
+    docker run --rm --privileged multiarch/qemu-user-static:register --privileged
+    cat /proc/sys/fs/binfmt_misc/qemu-arm
 fi
 
 sudo mount -o bind /dev $HOME/$ARCH/dev

--- a/.travis/setup_chroot.sh
+++ b/.travis/setup_chroot.sh
@@ -7,7 +7,7 @@ echo "macos doesn't use chroot, no need to mount."
 else
 
 if [ $ARCH == "armhf" ]; then
-    docker run --rm --privileged multiarch/qemu-user-static:register --credential
+    docker run --rm --privileged multiarch/qemu-user-static:register --credential yes
     cat /proc/sys/fs/binfmt_misc/qemu-arm
 fi
 

--- a/.travis/setup_chroot.sh
+++ b/.travis/setup_chroot.sh
@@ -7,7 +7,7 @@ echo "macos doesn't use chroot, no need to mount."
 else
 
 if [ $ARCH == "armhf" ]; then
-    docker run --rm --privileged multiarch/qemu-user-static:register --privileged
+    docker run --rm --privileged multiarch/qemu-user-static:register --credential
     cat /proc/sys/fs/binfmt_misc/qemu-arm
 fi
 

--- a/setup
+++ b/setup
@@ -210,6 +210,7 @@ case "${unameOut}" in
                         cd /usr/src/gtest; \
                         sudo cmake CMakeLists.txt; \
                         sudo make; \
+                        sudo make install; \
                         cd -; \
                         sudo rm /usr/local/lib/libgtest_main.a && sudo ln -n /usr/src/gtest/libgtest_main.a /usr/local/lib/libgtest_main.a; \
                         sudo rm /usr/local/lib/libgtest.a && sudo ln -n /usr/src/gtest/libgtest.a /usr/local/lib/libgtest.a;
@@ -223,6 +224,7 @@ case "${unameOut}" in
                                         cd /usr/src/gtest; \
                                         sudo cmake CMakeLists.txt; \
                                         sudo make; \
+                                        sudo make install; \
                                         cd -; \
                                         sudo rm /usr/local/lib/libgtest_main.a && sudo ln -n /usr/src/gtest/libgtest_main.a /usr/local/lib/libgtest_main.a; \
                                         sudo rm /usr/local/lib/libgtest.a && sudo ln -n /usr/src/gtest/libgtest.a /usr/local/lib/libgtest.a; \


### PR DESCRIPTION
## Overview

Description: This PR fixes an issue where the build fails because the qemu-arm binary translator is missing privilege permissions.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] Change is covered by automated tests
