### PR TITLE
[WIP] Initial docker skeleton

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+build
+.git
+doc
+*.img
+boards
+de10_support

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Index
 
 Dependencies
 =====
-Cascade should build successfully on OSX and most Linux distributions. 
+The easiest way to get started with Cascade is with Docker.
+With Docker, you'll only need an installation of [Docker](https://hub.docker.com/search/?type=edition&offering=community) to build and run Cascade.
+
 
 Building Cascade
 =====
@@ -61,17 +63,20 @@ Building Cascade
 *NIX $ git clone https://github.com/vmware/cascade cascade
 ```
 
-2. Run the setup script
+2. Build the Docker images
 
 ```bash
 *NIX $ cd cascade
-*NIX $ ./setup
+*NIX $ docker/build_images.sh
 ```
 
-The setup script should guide you through installing dependencies, as
-well as configuring, building and testing Cascade.
+The image builder should build two images: ```cascade-builder```, which contains the dependencies for building cascade,
+and ```cascade``, which builds and installs cascade. 
 
-Once installed, cascade should now be accessible by just typing ```cascade```.
+Once installed, cascade should now be accessible by running the cascade image:
+```bash
+*NIX $ docker run -it cascade:latest
+```
 
 Using Cascade
 =====
@@ -80,7 +85,7 @@ Using Cascade
 
 Start Cascade by typing
 ```
-*NIX $ cascade
+*NIX $ docker run -it cascade:latest
 ```
 This will place you in a Read-Evaluate-Print-Loop (REPL). Code which is typed
 here is appended to the source of the (initially empty) top-level (root) module
@@ -270,7 +275,7 @@ Environments
 By default, Cascade is started in a minimal environment. You can invoke this
 behavior explicitly using the ```--march``` flag.
 ```
-*NIX $ ./bin/cascade --march minimal
+*NIX $ docker run -it cascade:latest cascade --march minimal
 ```
 This environment declares the following module and instantiates it into the
 top-level module for you:
@@ -320,7 +325,7 @@ and run in software. However most hardware programs involve the use of I/O
 peripherals. Before we get into real hardware, first try running Cascade's
 virtual software FPGA.
 ```
-*NIX $ ./bin/sw_fpga
+*NIX $ docker run -it cascade:latest sw_fpga
 ```
 Cascade's virtual FPGA provides an ncurses GUI with four buttons, one reset,
 and eight leds. You can toggle the buttons using the ```1 2 3 4``` keys, toggle
@@ -328,7 +333,7 @@ the reset using the ```r``` key, and shut down the virtual FPGA by typing
 ```q```. In order to write code which uses these peripherals, restart Cascade
 using the ```--march sw``` flag on the same machine as the virtual FPGA.
 ```
-*NIX $ ./bin/cascade --march sw
+*NIX $ docker run -it cascade:latest cascade --march sw
 ```
 Cascade will automatically detect the virtual FPGA and expose its peripherals
 as modules which are implicitly declared and instantiated in the top-level

--- a/docker/build_images.sh
+++ b/docker/build_images.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+echo "Building docker images..."
+echo "Using root context: ${DIR}/.."
+
+echo "Building cascade-builder..."
+docker build --rm -f "${DIR}/dockerfiles/builder/Dockerfile" -t cascade-builder:latest ${DIR}/..
+
+echo "Building cascade..."
+docker build --rm -f "${DIR}/dockerfiles/cascade/Dockerfile" -t cascade:latest ${DIR}/..

--- a/docker/dockerfiles/builder/Dockerfile
+++ b/docker/dockerfiles/builder/Dockerfile
@@ -1,0 +1,23 @@
+# This docker base image is used to build Cascade.
+# It contains all the necessary dependencies to build and develop Cascade.
+
+FROM ubuntu:18.04 AS cascade-builder
+
+ARG MAKE_PARALLELISM=4
+
+RUN apt-get update && apt-get -y install \
+    build-essential \
+    cmake \
+    clang-8 \
+    clang-format-8 \
+    flex \
+    bison \
+    libncurses5-dev \
+    libbenchmark-dev \
+    libgtest-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# gtest binaries are not build by default, so build them and install
+RUN cd /usr/src/gtest && \
+    mkdir build && \
+    cmake .. && make -j ${MAKE_PARALLELISM} && make install && cd / && rm -rf /usr/src/gtest/build

--- a/docker/dockerfiles/cascade/Dockerfile
+++ b/docker/dockerfiles/cascade/Dockerfile
@@ -1,0 +1,15 @@
+FROM cascade-builder:latest AS cascade-builder
+
+WORKDIR /cascade
+COPY . /cascade
+
+# The type of build
+ARG BUILD_TYPE=RELWITHDEBINFO
+
+RUN mkdir build && \
+     cd build && \
+      cmake -DCMAKE_C_COMPILER=/usr/bin/clang-8 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-8 -DCMAKE_BUILD_TYPE=${BUILD_TYPE} .. && \ 
+      CTEST_OUTPUT_ON_FAILURE=true make -j$(nproc) all test && \
+      make install
+
+CMD [ "cascade" ]


### PR DESCRIPTION
## Overview

Description: This PR implements a basic Docker build, which should help eliminate the complexity of the build environment and dependencies. This would allow us to remove the setup script, provide a consistent environment for debugging --- and point users to the builder dockerfile if they wish to run natively. This would also make it easier to support Cascade, as docker should be available on Linux, Windows and macos.

It's a WIP and shouldn't be merged. A few things remain:

- [ ] Parts of Cascade expect to be running in the same machine (for example, sw_fpga). The documentation needs to be rewritten for containers
- [ ] Untested on the DE10. Presumably should work, but I/O and FPGA configuration probably needs to be exposed to the container somehow.
- [ ] Instructions for debugging in the Docker container. vscode and devcontainer support work fairly well, so we should at least document that for those looking to use the container-based environment.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated tests
