### PR TITLE
Propagate command failures in shell scripts by chaining them with &&.

### DIFF
--- a/share/cascade/de10/assemble_de10.sh
+++ b/share/cascade/de10/assemble_de10.sh
@@ -2,5 +2,5 @@
 
 #1 = path/to/intel/tools
 
-$1/bin/quartus_asm DE10_NANO_SoC_GHRD.qpf
+$1/bin/quartus_asm DE10_NANO_SoC_GHRD.qpf &&
 $1/bin/quartus_cpf -c sof2rbf.cof

--- a/share/cascade/de10/build_de10.sh
+++ b/share/cascade/de10/build_de10.sh
@@ -2,6 +2,6 @@
 
 #1 = path/to/intel/tools
 
-$1/sopc_builder/bin/qsys-generate soc_system.qsys --synthesis=VERILOG
-$1/bin/quartus_map DE10_NANO_SoC_GHRD.qpf
+$1/sopc_builder/bin/qsys-generate soc_system.qsys --synthesis=VERILOG &&
+$1/bin/quartus_map DE10_NANO_SoC_GHRD.qpf &&
 $1/bin/quartus_fit DE10_NANO_SoC_GHRD.qpf

--- a/share/cascade/ulx3s/build_ulx3s_32.sh
+++ b/share/cascade/ulx3s/build_ulx3s_32.sh
@@ -2,10 +2,8 @@
 
 # $1 = unique compilation name
 
-cd $1
-
-yosys -q -p "synth_ecp5 -json root32.json" root32.v
-nextpnr-ecp5 --json root32.json --textcfg root32.config --lpf ulx3s_v20.lpf --85k --package CABGA381
-ecppack --idcode 0x41113043 root32.config root32.bit
-
+cd $1 &&
+yosys -q -p "synth_ecp5 -json root32.json" root32.v &&
+nextpnr-ecp5 --json root32.json --textcfg root32.config --lpf ulx3s_v20.lpf --85k --package CABGA381 &&
+ecppack --idcode 0x41113043 root32.config root32.bit &&
 cd -


### PR DESCRIPTION
## Overview

Description:

When some command in the middle of the shell script fails shell by default keeps running subsequent commands, which isn't what is desired when you run a compiler chain. This patch chains the commands with &&. This way when one command would fail - the whole script would fail, which is a desired behavior.


Related issue(s) (if applicable): Fixes #<issue-number>

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated tests
